### PR TITLE
sdk: set delete=False

### DIFF
--- a/sdk/python/kadalu_volgen/__init__.py
+++ b/sdk/python/kadalu_volgen/__init__.py
@@ -30,7 +30,7 @@ def generate(template_file, data=None, data_file=None, options=None,
         args += ["--data", tmp_data_file_name]
 
     if options is not None:
-        with tempfile.NamedTemporaryFile(mode="w") as tmp_file:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp_file:
             for key, value in options.items():
                 tmp_file.file.write(f"{key}={value}\n")
             tmp_options_file_name = tmp_file.name


### PR DESCRIPTION
```Traceback (most recent call last):
  File "/kadalu/server.py", line 42, in <module>
    start_server_process()
  File "/kadalu/server.py", line 22, in start_server_process
    glusterfsd_proc = glusterfsd.start_args()
  File "/kadalu/glusterfsd.py", line 214, in start_args
    create_client_volfile(client_volfile_path, volname)
  File "/kadalu/glusterfsd.py", line 93, in create_client_volfile
    generate_client_volfile(data, client_volfile_path)
  File "/kadalu/serverutils.py", line 106, in generate_client_volfile
    kadalu_volgen.generate(
  File "/kadalu/lib/python3.10/site-packages/kadalu_volgen-0.2.0-py3.10.egg/kadalu_volgen/__init__.p
y", line 69, in generate
    raise VolfileException(proc.returncode, err.strip())
kadalu_volgen.VolfileException: [Errno 1] Unhandled exception: Error opening file with mode 'r': '/t
mp/tmptnamltu9': No such file or directory (File::NotFoundError)
```
Fixes above:
Signed-off-by: Shree Vatsa N [vatsa@kadalu.tech](mailto:vatsa@kadalu.tech)