### PR TITLE
Add support for setting option by giving xlator name

### DIFF
--- a/src/options.cr
+++ b/src/options.cr
@@ -23,9 +23,58 @@ module VolfileOptions
     true
   end
 
-  def self.parsed_option(volfile_type, option_name, option_value)
+  # Search each volfile elements to see if atleast one xlator
+  # exists with the given name
+  def self.xlator_name_exists?(elements, xlator_name)
+    elements.each do |element|
+      return true if element.name == xlator_name
+    end
+
+    false
+  end
+
+  # Search each volfile elements to see if atleast one xlator
+  # exists with the given type
+  def self.xlator_type_exists?(elements, xlator_type)
+    elements.each do |element|
+      return true if element.type == xlator_type
+    end
+
+    false
+  end
+
+  def self.parsed_option(volfile_type, option_name, option_value, elements)
     opt_conf = @@options_map[option_name]?
-    return Options.new unless opt_conf
+
+    # option is not found in the supported list of options.
+    # It may be possible that use might have given the option
+    # directly by giving the xlator name or by giving the name that
+    # will be used to represent in the Volfile. For example,
+    # debug/io-stats.log-level=debug  OR
+    # /exports/pool1/s1.log-level=debug to apply this setting only for
+    # the storage unit that contains the path `/exports/pool1/s1`
+    # ```
+    # volume /exports/pool1/s1
+    #     type debug/io-stats
+    #     option log-level debug
+    #     subvolumes pool1-index
+    # end-volume
+    # ```
+    unless opt_conf
+      xlator_or_name, _sep, opt = option_name.partition(".")
+      return Options.new if opt == ""
+
+      if xlator_name_exists?(elements, xlator_or_name) || xlator_type_exists?(elements, xlator_or_name)
+        return {
+          xlator_or_name => {
+            opt => option_value,
+          },
+        }
+      end
+
+      return Options.new
+    end
+
     return Options.new unless opt_conf.type == "" || opt_conf.type == volfile_type
 
     # If option name is empty in the configuration
@@ -46,10 +95,10 @@ module VolfileOptions
     }
   end
 
-  def self.parsed_options(volfile_type, options)
+  def self.parsed_options(volfile_type, options, elements)
     parsed = Options.new
     options.each do |key, value|
-      parsed.merge!(parsed_option(volfile_type, key, value))
+      parsed.merge!(parsed_option(volfile_type, key, value, elements))
     end
     parsed
   end

--- a/src/supported_options.cr
+++ b/src/supported_options.cr
@@ -1,3 +1,25 @@
+# Add all the options that can be used with `kadalu` or
+# `kubectl_kadalu` commands.
+#
+# The helper block `VolfileOptions.option_config` accepts the
+# option name as a string or list of strings when one option has aliases.
+#
+# Example:
+# ```
+# VolfileOptions.option_config "diagnostics.client-log-level" do |opt|
+#   opt.type = "client"
+#   opt.name = "log-level"
+#   opt.xlator = "debug/io-stats"
+#   opt.allowed_values = LOG_LEVELS
+# end
+# ```
+#
+# Define `type`, `name`, `xlator`, `allowed_values`
+# - `type` - Template type. `client` template or `storage_unit` template
+# - `name` - Name of the option. If name of the option is not provided then
+#            this option will be used to enable or disable the Xlator.
+# - `xlator` - Name of the xlator to which this option belongs to.
+# - `allowed_values` - If the option should accept only the given list of values.
 require "./helpers"
 
 LOG_LEVELS = ["info", "error", "debug"]


### PR DESCRIPTION
or the name from the generated volfile.

Example 1: By using xlator name

```
debug/io-stats.log-level=DEBUG
```

Above sets log-level to both client, storage_unit volfiles or in all volfiles that contains `debug/io-stats` xlator.

Example 2: By using name from the volfile

```
/exports/pool1/s1.log-level=DEBUG
```

Above sets the log level of storage unit volfile that belongs to the storage unit `/exports/pool1/s1`

```
volume /exports/pool1/s1
    type debug/io-stats
    option unique-id /no/such/path
    option log-level DEBUG
    subvolumes vol1-index
end-volume
```

Example 3: By using name from the volfile

```
vol1-client-0.remote-host=server1.example.com
vol1-client-1.remote-host=server2.example.com
vol1-client-2.remote-host=server3.example.com
```

Above options sets the host name of servers as required. If different IP to be used for client to server communications then set the option as above for each `protocol/client` elements in the volfile.

```
volume vol1-client-0
    type protocol/client
    option transport.socket.read-fail-log false
    option volfile-key /vol1
    option remote-subvolume /exports/vol1/s1
    option remote-host server1.example.com
    option remote-port 4501
end-volume
```